### PR TITLE
Fix GameState init docstring

### DIFF
--- a/game_states/game.py
+++ b/game_states/game.py
@@ -127,8 +127,8 @@ class GameState(GameStateBase):
 
         Parameters
         ----------
-        board : list[list[int]], optional
-            The starting board. Defaults to `start_board`.
+        board : tuple[int, ...] | None, optional
+            The starting board as a tuple of 64 integers. Defaults to ``start_board``.
         white_queen : bool, optional
             Whether the white queen is still on the board. Defaults to True.
         white_king : bool, optional


### PR DESCRIPTION
## Summary
- update board type hint in `GameState.__init__` docstring

## Testing
- `pytest -q` *(fails: SyntaxError in utils.py)*

------
https://chatgpt.com/codex/tasks/task_e_68794e64d0208329a4e7c977a31c7f5d